### PR TITLE
Updating the up-client-zenoh-cpp version to 0.1.1-dev

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,7 @@ class HelloWorldRecipe(ConanFile):
     #     self.options["spdlog"].shared = self.options.shared
 
     def requirements(self):
-        self.requires("up-client-zenoh-cpp/0.1.0-dev")
+        self.requires("up-client-zenoh-cpp/0.1.1-dev")
         self.requires("protobuf/3.21.12" + ("@cross/cross" if self.options.build_cross_compiling else ""))
             
 


### PR DESCRIPTION
Updating the up-client-zenoh-cpp version to 0.1.1-dev due to a bug fix in RPC server