### PR TITLE
Continue PR #5 - Fix CI build issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Build up-zenoh-example-cpp
         shell: bash
         run: |
-          export GITHUB_CICD_ZENOH_PATH="$HOME/local/lib/libzenohc.a"
+          export GITHUB_CICD_ZENOH_PATH="$HOME/local/lib"
           export CMAKE_ZENOH_INCLUDE_PATH="$HOME/local/include"
           mkdir build
           cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
         run: |
           git clone https://github.com/eclipse-uprotocol/up-cpp.git
           cd up-cpp
-          git clone -b uprotocol-core-api-1.5.6 https://github.com/eclipse-uprotocol/up-core-api.git
           git submodule update --init --recursive
           conan create . --build=missing
 
@@ -44,24 +43,27 @@ jobs:
         run: |
           git clone https://github.com/eclipse-zenoh/zenoh-c.git
           cd zenoh-c && mkdir -p build && cd build 
-          cmake .. -DCMAKE_BUILD_TYPE=Release
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/local -DZENOHC_INSTALL_STATIC_LIBRARY=TRUE
           cmake --build . --target install --config Release -- -j
-
+          
       - name: Create up-client-zenoh-cpp Conan package
         shell: bash
         run: |
+          export CMAKE_PREFIX_PATH="$HOME/local"
+          export CMAKE_ZENOH_INCLUDE_PATH="$HOME/local/include"
           git clone https://github.com/eclipse-uprotocol/up-client-zenoh-cpp.git
           cd up-client-zenoh-cpp
-          conan create . --build=missing
-
+          conan create .
       - name: Build up-zenoh-example-cpp
         shell: bash
         run: |
-          mkdir build_samples
-          cd build_samples
-          conan install ../
-          cmake ../ -DCMAKE_TOOLCHAIN_FILE=generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release
-          cmake --build . 
+          export GITHUB_CICD_ZENOH_PATH="$HOME/local/lib/libzenohc.a"
+          export CMAKE_ZENOH_INCLUDE_PATH="$HOME/local/include"
+          mkdir build
+          cd build
+          conan install ..
+          cmake -S .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release 
+          cmake --build .
 
   
   # NOTE: In GitHub repository settings, the "Require status checks to pass

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,4 +24,4 @@ cmake_minimum_required(VERSION 3.20)
 project(samples VERSION 0.1.0 LANGUAGES CXX)
 
 add_subdirectory(pubsub)
-add_subdirectory(rpc)
+#add_subdirectory(rpc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,4 +24,4 @@ cmake_minimum_required(VERSION 3.20)
 project(samples VERSION 0.1.0 LANGUAGES CXX)
 
 add_subdirectory(pubsub)
-#add_subdirectory(rpc)
+add_subdirectory(rpc)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 
-class HelloWorldRecipe(ConanFile):
+class UpZenohExampleRecipe(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "CMakeDeps", "CMakeToolchain", "PkgConfigDeps", "VirtualRunEnv", "VirtualBuildEnv"
     options = {
@@ -19,14 +19,12 @@ class HelloWorldRecipe(ConanFile):
         "build_cross_compiling": False,
     }
 
-    # def configure(self):
-    #     self.options["spdlog"].shared = self.options.shared
-
     def requirements(self):
-        self.requires("up-client-zenoh-cpp/0.1.0-dev")
+        self.requires("spdlog/1.13.0")
+        self.requires("up-cpp/0.1.1-dev")
+        self.requires("up-client-zenoh-cpp/0.1.2-dev")
         self.requires("protobuf/3.21.12" + ("@cross/cross" if self.options.build_cross_compiling else ""))
             
-
     def imports(self):
         if self.options.build_testing:
             self.copy("*.so*", dst="lib", keep_path=False)

--- a/pubsub/CMakeLists.txt
+++ b/pubsub/CMakeLists.txt
@@ -35,12 +35,28 @@ else()
     find_library(ZENOH_LIB zenohc)
 endif() 
 
+if(BUILD_UNBUNDLED)
+    find_package(zenohc REQUIRED)
+    set(ZENOH_LIBRARY zenohc::lib)
+else()
+    if(CROSS_COMPILE)
+        find_package(zenohc REQUIRED)
+	set(ZENOH_LIBRARY zenohc::lib)
+    else()
+        find_library(ZENOH_LIB zenohc)
+	set(ZENOH_LIBRARY ${ZENOH_LIB})
+    endif()
+endif()
+
+message("MICHAEL ${ZENOH_LIBRARY}")
+
 # sub
 add_executable(sub src/main_sub.cpp)
 target_link_libraries(sub
     PUBLIC
-        ${ZENOH_LIB}
-        up-client-zenoh-cpp::up-client-zenoh-cpp)
+        up-client-zenoh-cpp::up-client-zenoh-cpp
+    PRIVATE
+        ${ZENOH_LIBRARY})
 
 target_include_directories(sub 
     PUBLIC
@@ -53,8 +69,9 @@ target_include_directories(sub
 add_executable(pub src/main_pub.cpp)
 target_link_libraries(pub
     PUBLIC
-        ${ZENOH_LIB}
-        up-client-zenoh-cpp::up-client-zenoh-cpp)
+        up-client-zenoh-cpp::up-client-zenoh-cpp
+    PRIVATE
+        ${ZENOH_LIBRARY})
 
 target_include_directories(pub 
     PUBLIC

--- a/pubsub/CMakeLists.txt
+++ b/pubsub/CMakeLists.txt
@@ -30,25 +30,23 @@ find_package(up-cpp QUIET)
 add_definitions(-DSPDLOG_FMT_EXTERNAL)
 
 if(DEFINED ENV{GITHUB_CICD_ZENOH_PATH})
-    set(ZENOH_LIB $ENV{GITHUB_CICD_ZENOH_PATH})
+    set(ZENOH_LINK_FLAGS -Wl,--no-as-needed)
+    set(LIB_SEARCH -L$ENV{GITHUB_CICD_ZENOH_PATH})
+    set(ZENOH_LIBRARY -lzenohc)
 else()
-    find_library(ZENOH_LIB zenohc)
-endif() 
 
-if(BUILD_UNBUNDLED)
-    find_package(zenohc REQUIRED)
-    set(ZENOH_LIBRARY zenohc::lib)
-else()
-    if(CROSS_COMPILE)
+    if(BUILD_UNBUNDLED)
         find_package(zenohc REQUIRED)
-	set(ZENOH_LIBRARY zenohc::lib)
+        set(ZENOH_LIBRARY zenohc::lib)
     else()
-        find_library(ZENOH_LIB zenohc)
-	set(ZENOH_LIBRARY ${ZENOH_LIB})
+        if(CROSS_COMPILE)
+            find_package(zenohc REQUIRED)
+            set(ZENOH_LIBRARY zenohc::lib)
+        else()
+            find_library(ZENOH_LIBRARY zenohc)
+        endif()
     endif()
 endif()
-
-message("MICHAEL ${ZENOH_LIBRARY}")
 
 # sub
 add_executable(sub src/main_sub.cpp)
@@ -56,9 +54,11 @@ target_link_libraries(sub
     PUBLIC
         up-client-zenoh-cpp::up-client-zenoh-cpp
     PRIVATE
+        ${LIB_SEARCH}
+        ${ZENOH_LINK_FLAGS}
         ${ZENOH_LIBRARY})
 
-target_include_directories(sub 
+target_include_directories(sub
     PUBLIC
         $ENV{CMAKE_ZENOH_INCLUDE_PATH}
         ${fmt_INCLUDE_DIR}
@@ -71,9 +71,11 @@ target_link_libraries(pub
     PUBLIC
         up-client-zenoh-cpp::up-client-zenoh-cpp
     PRIVATE
+        ${LIB_SEARCH}
+        ${ZENOH_LINK_FLAGS}
         ${ZENOH_LIBRARY})
 
-target_include_directories(pub 
+target_include_directories(pub
     PUBLIC
         $ENV{CMAKE_ZENOH_INCLUDE_PATH}
         ${fmt_INCLUDE_DIR}

--- a/pubsub/CMakeLists.txt
+++ b/pubsub/CMakeLists.txt
@@ -23,16 +23,42 @@
 cmake_minimum_required(VERSION 3.20)
 project(pubsub VERSION 0.1.0 LANGUAGES CXX)
 
-find_package(up-client-zenoh-cpp REQUIRED)
+find_package(spdlog REQUIRED)
+find_package(up-client-zenoh-cpp QUIET)
+find_package(up-cpp QUIET)
+
+add_definitions(-DSPDLOG_FMT_EXTERNAL)
+
+if(DEFINED ENV{GITHUB_CICD_ZENOH_PATH})
+    set(ZENOH_LIB $ENV{GITHUB_CICD_ZENOH_PATH})
+else()
+    find_library(ZENOH_LIB zenohc)
+endif() 
 
 # sub
 add_executable(sub src/main_sub.cpp)
 target_link_libraries(sub
-    PRIVATE
+    PUBLIC
+        ${ZENOH_LIB}
         up-client-zenoh-cpp::up-client-zenoh-cpp)
+
+target_include_directories(sub 
+    PUBLIC
+        $ENV{CMAKE_ZENOH_INCLUDE_PATH}
+        ${fmt_INCLUDE_DIR}
+        ${spdlog_INCLUDE_DIR}
+        ${up-cpp_INCLUDE_DIR})
 
 # pub
 add_executable(pub src/main_pub.cpp)
 target_link_libraries(pub
-    PRIVATE
+    PUBLIC
+        ${ZENOH_LIB}
         up-client-zenoh-cpp::up-client-zenoh-cpp)
+
+target_include_directories(pub 
+    PUBLIC
+        $ENV{CMAKE_ZENOH_INCLUDE_PATH}
+        ${fmt_INCLUDE_DIR}
+        ${spdlog_INCLUDE_DIR}
+        ${up-cpp_INCLUDE_DIR})

--- a/rpc/CMakeLists.txt
+++ b/rpc/CMakeLists.txt
@@ -27,21 +27,36 @@ find_package(spdlog REQUIRED)
 find_package(up-client-zenoh-cpp QUIET)
 find_package(up-cpp QUIET)
 
-# this is needed until zenoh will be released to the public conan central
-if(DEFINED ENV{GITHUB_CICD_ZENOH_PATH})
-    set(ZENOH_LIB $ENV{GITHUB_CICD_ZENOH_PATH})
-else()
-    find_library(ZENOH_LIB zenohc)
-endif() 
-
 add_definitions(-DSPDLOG_FMT_EXTERNAL)
+
+if(DEFINED ENV{GITHUB_CICD_ZENOH_PATH})
+    set(ZENOH_LINK_FLAGS -Wl,--no-as-needed)
+    set(LIB_SEARCH -L$ENV{GITHUB_CICD_ZENOH_PATH})
+    set(ZENOH_LIBRARY -lzenohc)
+else()
+
+    if(BUILD_UNBUNDLED)
+        find_package(zenohc REQUIRED)
+        set(ZENOH_LIBRARY zenohc::lib)
+    else()
+        if(CROSS_COMPILE)
+            find_package(zenohc REQUIRED)
+            set(ZENOH_LIBRARY zenohc::lib)
+        else()
+            find_library(ZENOH_LIBRARY zenohc)
+        endif()
+    endif()
+endif()
 
 # rpc client
 add_executable(rpc_client src/main_rpc_client.cpp)
 target_link_libraries(rpc_client
     PUBLIC
-        ${ZENOH_LIB}
-        up-client-zenoh-cpp::up-client-zenoh-cpp)
+        up-client-zenoh-cpp::up-client-zenoh-cpp
+    PRIVATE
+        ${LIB_SEARCH}
+        ${ZENOH_LINK_FLAGS}
+        ${ZENOH_LIBRARY})
 
 target_include_directories(rpc_client 
     PUBLIC
@@ -54,8 +69,11 @@ target_include_directories(rpc_client
 add_executable(rpc_server src/main_rpc_server.cpp)
 target_link_libraries(rpc_server
     PUBLIC
-        ${ZENOH_LIB}
-        up-client-zenoh-cpp::up-client-zenoh-cpp)
+        up-client-zenoh-cpp::up-client-zenoh-cpp
+    PRIVATE
+        ${LIB_SEARCH}
+        ${ZENOH_LINK_FLAGS}
+        ${ZENOH_LIBRARY})
 
 target_include_directories(rpc_server 
     PUBLIC

--- a/rpc/CMakeLists.txt
+++ b/rpc/CMakeLists.txt
@@ -23,16 +23,43 @@
 cmake_minimum_required(VERSION 3.20)
 project(rpc VERSION 0.1.0 LANGUAGES CXX)
 
-find_package(up-client-zenoh-cpp REQUIRED)
+find_package(spdlog REQUIRED)
+find_package(up-client-zenoh-cpp QUIET)
+find_package(up-cpp QUIET)
 
-# rpc server
-add_executable(rpc_server src/main_rpc_server.cpp)
-target_link_libraries(rpc_server
-    PRIVATE
-        up-client-zenoh-cpp::up-client-zenoh-cpp)
+# this is needed until zenoh will be released to the public conan central
+if(DEFINED ENV{GITHUB_CICD_ZENOH_PATH})
+    set(ZENOH_LIB $ENV{GITHUB_CICD_ZENOH_PATH})
+else()
+    find_library(ZENOH_LIB zenohc)
+endif() 
+
+add_definitions(-DSPDLOG_FMT_EXTERNAL)
 
 # rpc client
 add_executable(rpc_client src/main_rpc_client.cpp)
 target_link_libraries(rpc_client
-    PRIVATE
+    PUBLIC
+        ${ZENOH_LIB}
         up-client-zenoh-cpp::up-client-zenoh-cpp)
+
+target_include_directories(rpc_client 
+    PUBLIC
+        $ENV{CMAKE_ZENOH_INCLUDE_PATH}
+        ${fmt_INCLUDE_DIR}
+        ${spdlog_INCLUDE_DIR}
+        ${up-cpp_INCLUDE_DIR})
+
+# rpc server
+add_executable(rpc_server src/main_rpc_server.cpp)
+target_link_libraries(rpc_server
+    PUBLIC
+        ${ZENOH_LIB}
+        up-client-zenoh-cpp::up-client-zenoh-cpp)
+
+target_include_directories(rpc_server 
+    PUBLIC
+        $ENV{CMAKE_ZENOH_INCLUDE_PATH}
+        ${fmt_INCLUDE_DIR}
+        ${spdlog_INCLUDE_DIR}
+        ${up-cpp_INCLUDE_DIR})

--- a/rpc/src/main_rpc_server.cpp
+++ b/rpc/src/main_rpc_server.cpp
@@ -57,9 +57,10 @@ class RpcListener : public UListener {
 
             UPayload responsePayload(reinterpret_cast<const uint8_t*>(&currentTimeMilli), sizeof(currentTimeMilli), UPayloadType::VALUE);
            
-            auto builder = UAttributesBuilder::response(message.attributes().source(), message.attributes().sink(), UPriority::UPRIORITY_CS0, message.attributes().id());
-            /* Build response attributes - the same UUID should be used to send the response 
-             * it is also possible to send the response outside of the callback context */
+            auto builder = UAttributesBuilder::response(message.attributes().sink(), message.attributes().source(), UPriority::UPRIORITY_CS0, message.attributes().reqid());
+            /* Build response attributes - the request UUID should be used to send the response.
+             * Source and sink are swapped for replies since the message is going back to where it originated.
+             * It is also possible to send the response outside of the callback context */
 
             UAttributes responseAttributes = builder.build();
 


### PR DESCRIPTION
This PR is a replacement for PR #5 with fixes for the CI build issues. Commit b0fab14 contains the entirety of #5 up to the last approval (at ef150c8) squashed into a single commit. The following commit (85c5bda) contains @MelamudMichael's efforts to address CI build issues, again squashed into a single commit. Finally, 635b54a contains my fix for the CI build issue.

----

### Fix missing zenoh-c symbols in CI build

Address failing CI build (missing zenoh-c symbols) by switching to no-as-needed linking for zenoh-c and using a different library search technique in cmake.

Adding -Wl,--no-as-needed is necessary when linking an application against a static library where *another* library is dependent on that static library's symbols. In this case, up-client-zenoh-cpp depends on zenoh-c, but does not incorporate those symbols directly. At link time, the linker will look at the symbols provided by zenoh-c and the symbols needed for the application binary, determine none are needed, and discard them. The -Wl,--no-as-needed flag tells the linker to embed those symbols into the application binary anyway.

It was also necessary to explicitly pass a search directory and library name to the linker instead of providing cmake a path to a static library file. It is unclear why providing a library path was not working - the documentation indicates it should. However, using standard -L<path> and -l<library> flags did resolve the issue.

I tested with each of the above solutions independently and neither one worked on its own. Both were required to fix the CI build.

This change also re-enables build for examples that were previously disabled.

----

### Instructions for completing the review:

1. Using ➡️ **[this link](https://github.com/eclipse-uprotocol/up-zenoh-example-cpp/pull/5/files/2c1877126284516268943c371cc9329243f2d46b..ef150c8872b1980b5251399318ae98fee44d51ce)** ⬅️, review #5 
2. Comment on or approve #5 
3. Using ➡️ **[this comparison](https://github.com/eclipse-uprotocol/up-zenoh-example-cpp/compare/ef150c8872b1980b5251399318ae98fee44d51ce..b0fab14272de57978e0014bfbe2741d8280607bc)** ⬅️, confirm that the repo at ef150c8 and b0fab14 contains identical files
4. Using ➡️ **[this link](https://github.com/eclipse-uprotocol/up-zenoh-example-cpp/pull/9/files/b0fab14272de57978e0014bfbe2741d8280607bc..635b54a2a9ae96409f8b121a564e76758f8acde9)** ⬅️, review the changes in *this* PR
5. Comment on or approve *this* PR
6. **(When both PRs approved)** Close #5 and merge *this* PR (without squashing any further)