### PR TITLE
Speed up CI jobs with parallelism and caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Build up-zenoh-example-cpp
         shell: bash
         run: |
-          export GITHUB_CICD_ZENOH_PATH="$HOME/local/lib/libzenohc.a"
+          export GITHUB_CICD_ZENOH_PATH="$HOME/local/lib"
           export CMAKE_ZENOH_INCLUDE_PATH="$HOME/local/include"
           mkdir build
           cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
         run: |
           git clone https://github.com/eclipse-uprotocol/up-cpp.git
           cd up-cpp
-          git clone -b uprotocol-core-api-1.5.6 https://github.com/eclipse-uprotocol/up-core-api.git
           git submodule update --init --recursive
           conan create . --build=missing
 
@@ -44,24 +43,27 @@ jobs:
         run: |
           git clone https://github.com/eclipse-zenoh/zenoh-c.git
           cd zenoh-c && mkdir -p build && cd build 
-          cmake .. -DCMAKE_BUILD_TYPE=Release
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/local -DZENOHC_INSTALL_STATIC_LIBRARY=TRUE
           cmake --build . --target install --config Release -- -j
-
+          
       - name: Create up-client-zenoh-cpp Conan package
         shell: bash
         run: |
+          export CMAKE_PREFIX_PATH="$HOME/local"
+          export CMAKE_ZENOH_INCLUDE_PATH="$HOME/local/include"
           git clone https://github.com/eclipse-uprotocol/up-client-zenoh-cpp.git
           cd up-client-zenoh-cpp
-          conan create . --build=missing
-
+          conan create .
       - name: Build up-zenoh-example-cpp
         shell: bash
         run: |
-          mkdir build_samples
-          cd build_samples
-          conan install ../
-          cmake ../ -DCMAKE_TOOLCHAIN_FILE=generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release
-          cmake --build . 
+          export GITHUB_CICD_ZENOH_PATH="$HOME/local/lib/libzenohc.a"
+          export CMAKE_ZENOH_INCLUDE_PATH="$HOME/local/include"
+          mkdir build
+          cd build
+          conan install ..
+          cmake -S .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release 
+          cmake --build .
 
   
   # NOTE: In GitHub repository settings, the "Require status checks to pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,56 +9,213 @@ on:
   workflow_dispatch:
   
 jobs:
-  build:
-    name: Build
+  build-zenoh-c:
+    name: Build Zenoh-C
     runs-on: ubuntu-latest
+    env:
+      Zenoh_C_Repo: https://github.com/eclipse-zenoh/zenoh-c.git
+      Zenoh_C_Cache_PFX: libzenohc
+    outputs:
+      Zenoh_C_Cache: ${{ env.Zenoh_C_Cache_PFX }}-${{ steps.zenoh-c-head.outputs.Zenoh_C_HEAD }}
 
     steps:
+      - name: Check remote head hash
+        id: zenoh-c-head
+        shell: bash
+        run: '{ echo -n "Zenoh_C_HEAD="; git ls-remote "$Zenoh_C_Repo" HEAD | cut -f1; } | tee -a "$GITHUB_OUTPUT"'
+
+      - name: Cache compiled zenoh-c library
+        id: cache-libzenohc
+        uses: actions/cache@v4
+        with:
+          key: ${{ env.Zenoh_C_Cache_PFX }}-${{ steps.zenoh-c-head.outputs.Zenoh_C_HEAD }}
+          path: |
+            ~/local
+
+      - name: Install Rust toolchain
+        if: ${{ steps.cache-libzenohc.outputs.cache-hit != 'true' }}
+        run: rustup component add rustfmt clippy
+
+      # NOTE: Checks out the head revision we found using ls-remote above
+      #       to avoid race conditions resulting in mismatch between cache
+      #       and contents of repo.
+      - name: Clone Zenoh-C
+        if: ${{ steps.cache-libzenohc.outputs.cache-hit != 'true' }}
+        env:
+          Zenoh_C_HEAD: ${{ steps.zenoh-c-head.outputs.Zenoh_C_HEAD }}
+        shell: bash
+        run: |
+          pwd
+          git clone "$Zenoh_C_Repo"
+          cd zenoh-c && git checkout "$Zenoh_C_HEAD"
+
+      - name: Build and install Zenoh-C
+        if: ${{ steps.cache-libzenohc.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          mkdir -p zenoh-c/build && cd zenoh-c/build
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/local -DZENOHC_INSTALL_STATIC_LIBRARY=TRUE
+          cmake --build . --target install --config Release -- -j
+
+  build-up-cpp:
+    name: Build up-cpp
+    runs-on: ubuntu-latest
+    env:
+      UP_CPP_Repo: https://github.com/eclipse-uprotocol/up-cpp.git
+      UP_CPP_Cache_PFX: up-cpp-conan2
+    outputs:
+      UP_CPP_Cache: ${{ env.UP_CPP_Cache_PFX }}-${{ steps.up-cpp-head.outputs.UP_CPP_HEAD }}
+
+    steps:
+      - name: Check remote head hash
+        id: up-cpp-head
+        shell: bash
+        run: '{ echo -n "UP_CPP_HEAD="; git ls-remote "$UP_CPP_Repo" HEAD | cut -f1; } | tee -a "$GITHUB_OUTPUT"'
+
+      - name: Cache conan artifacts
+        id: cache-conan2
+        uses: actions/cache@v4
+        with:
+          key: ${{ env.UP_CPP_Cache_PFX }}-${{ steps.up-cpp-head.outputs.UP_CPP_HEAD }}
+          path: |
+            ~/.conan2
+
+      - name: Install Conan
+        if: ${{ steps.cache-conan2.outputs.cache-hit != 'true' }}
+        id: conan
+        uses: turtlebrowser/get-conan@main
+
+      - name: Create default Conan profile
+        if: ${{ steps.cache-conan2.outputs.cache-hit != 'true' }}
+        run: conan profile detect
+
+      # NOTE: Checks out the head revision we found using ls-remote above
+      #       to avoid race conditions resulting in mismatch between cache
+      #       and contents of repo.
+      - name: Clone up-cpp repo
+        if: ${{ steps.cache-conan2.outputs.cache-hit != 'true' }}
+        shell: bash
+        env:
+          UP_CPP_HEAD: ${{ steps.up-cpp-head.outputs.UP_CPP_HEAD }}
+        run: |
+          git clone "$UP_CPP_Repo"
+          cd up-cpp && git checkout "$UP_CPP_HEAD"
+          git submodule update --init --recursive
+
+      - name: Create up-cpp Conan package
+        if: ${{ steps.cache-conan2.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          cd up-cpp
+          conan create . --build=missing
+
+      - name: Clean up conan build files
+        if: ${{ steps.cache-conan2.outputs.cache-hit != 'true' }}
+        run: conan cache clean '*'
+
+  build-up-client-zenoh-cpp:
+    name: Build up-client-zenoh-cpp
+    needs: [ build-zenoh-c, build-up-cpp ]
+    runs-on: ubuntu-latest
+    env:
+      UP_Client_Z_Repo: eclipse-uprotocol/up-client-zenoh-cpp
+      UP_Client_Z_Cache_PFX: up-client-zenoh-conan2
+      Zenoh_C_Cache: ${{ needs.build-zenoh-c.outputs.Zenoh_C_Cache }}
+      UP_CPP_Cache: ${{ needs.build-up-cpp.outputs.UP_CPP_Cache }}
+    outputs:
+      UP_Client_Z_Cache: ${{ env.UP_Client_Z_Cache_PFX }}-${{ steps.up-client-zenoh-head.outputs.UP_Client_Z_HEAD }}
+
+    steps:
+      - name: Check remote head hash
+        id: up-client-zenoh-head
+        shell: bash
+        run: '{ echo -n "UP_Client_Z_HEAD="; git ls-remote "https://github.com/$UP_Client_Z_Repo".git HEAD | cut -f1; } | tee -a "$GITHUB_OUTPUT"'
+
+      - name: Cache client artifacts
+        id: cache-z-client
+        uses: actions/cache@v4
+        with:
+          key: ${{ env.UP_Client_Z_Cache_PFX }}-${{ steps.up-client-zenoh-head.outputs.UP_Client_Z_HEAD }}
+          path: |
+            ~/.conan2
+            ~/local
+
+      # Note: will never update here since it will always match from previous job
+      - name: Get cached zenoh-c library
+        if: ${{ steps.cache-z-client.outputs.cache-hit != 'true' }}
+        uses: actions/cache@v4
+        with:
+          fail-on-cache-miss: true
+          key: ${{ env.Zenoh_C_Cache }}
+          path: |
+            ~/local
+
+      # Note: will never update here since it will always match from previous job
+      - name: Get cached up-cpp conan artifacts
+        if: ${{ steps.cache-z-client.outputs.cache-hit != 'true' }}
+        uses: actions/cache@v4
+        with:
+          fail-on-cache-miss: true
+          key: ${{ env.UP_CPP_Cache }}
+          path: |
+            ~/.conan2
+
+      - name: Install Conan
+        if: ${{ steps.cache-z-client.outputs.cache-hit != 'true' }}
+        id: conan
+        uses: turtlebrowser/get-conan@main
+
       - uses: actions/checkout@v4
+        if: ${{ steps.cache-z-client.outputs.cache-hit != 'true' }}
+        with:
+          repository: ${{ env.UP_Client_Z_Repo }}
+          ref: ${{ steps.up-client-zenoh-head.outputs.UP_Client_Z_HEAD }}
+          path: up-client-zenoh-cpp
+
+      - name: Create up-client-zenoh-cpp Conan package
+        if: ${{ steps.cache-z-client.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          export CMAKE_PREFIX_PATH="$HOME/local"
+          export CMAKE_ZENOH_INCLUDE_PATH="$HOME/local/include"
+          cd up-client-zenoh-cpp
+          conan create .
+
+      - name: Clean up conan build files
+        if: ${{ steps.cache-z-client.outputs.cache-hit != 'true' }}
+        run: conan cache clean '*'
+
+  build-up-zenoh-example-cpp:
+    name: Build up-zenoh-example-cpp
+    needs: [ build-up-client-zenoh-cpp ]
+    runs-on: ubuntu-latest
+    env:
+      UP_Client_Z_Cache: ${{ needs.build-up-client-zenoh-cpp.outputs.UP_Client_Z_Cache }}
+
+    steps:
+      # Note: will never update here since it will always match from previous job
+      - name: Get cached up-client-zenoh-cpp library
+        uses: actions/cache@v4
+        with:
+          fail-on-cache-miss: true
+          key: ${{ env.UP_Client_Z_Cache }}
+          path: |
+            ~/.conan2
+            ~/local
 
       - name: Install Conan
         id: conan
         uses: turtlebrowser/get-conan@main
 
-      - name: Conan version
-        run: echo "${{ steps.conan.outputs.version }}"
+      - uses: actions/checkout@v4
 
-
-      - name: Create default Conan profile
-        run: conan profile detect
-
-      - name: Install Rust toolchain
-        run: rustup component add rustfmt clippy
-
-      - name: Create up-cpp Conan package
-        shell: bash
-        run: |
-          git clone https://github.com/eclipse-uprotocol/up-cpp.git
-          cd up-cpp
-          git submodule update --init --recursive
-          conan create . --build=missing
-
-      - name: Build and install Zenoh-C
-        shell: bash
-        run: |
-          git clone https://github.com/eclipse-zenoh/zenoh-c.git
-          cd zenoh-c && mkdir -p build && cd build 
-          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/local -DZENOHC_INSTALL_STATIC_LIBRARY=TRUE
-          cmake --build . --target install --config Release -- -j
-          
-      - name: Create up-client-zenoh-cpp Conan package
-        shell: bash
-        run: |
-          export CMAKE_PREFIX_PATH="$HOME/local"
-          export CMAKE_ZENOH_INCLUDE_PATH="$HOME/local/include"
-          git clone https://github.com/eclipse-uprotocol/up-client-zenoh-cpp.git
-          cd up-client-zenoh-cpp
-          conan create .
       - name: Build up-zenoh-example-cpp
         shell: bash
         run: |
-          export GITHUB_CICD_ZENOH_PATH="$HOME/local/lib"
+          export CMAKE_PREFIX_PATH="$HOME/local"
+          export CMAKE_LIBRARY_PATH_FLAG="$CMAKE_PREFIX_PATH/lib"
           export CMAKE_ZENOH_INCLUDE_PATH="$HOME/local/include"
+          export GITHUB_CICD_ZENOH_PATH="$CMAKE_LIBRARY_PATH_FLAG/libzenohc.a"
           mkdir build
           cd build
           conan install ..
@@ -74,7 +231,7 @@ jobs:
   ci:
     name: CI status checks
     runs-on: ubuntu-latest
-    needs: build
+    needs: [ build-zenoh-c, build-up-cpp, build-up-client-zenoh-cpp, build-up-zenoh-example-cpp ]
     if: always()
     steps:
       - name: Check whether all jobs pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: ["**"]
   workflow_call:
   workflow_dispatch:
-  
+
 jobs:
   build-zenoh-c:
     name: Build Zenoh-C
@@ -15,6 +15,7 @@ jobs:
     env:
       Zenoh_C_Repo: https://github.com/eclipse-zenoh/zenoh-c.git
       Zenoh_C_Cache_PFX: libzenohc
+      Zenoh_C_Build_Rev: HEAD
     outputs:
       Zenoh_C_Cache: ${{ env.Zenoh_C_Cache_PFX }}-${{ steps.zenoh-c-head.outputs.Zenoh_C_HEAD }}
 
@@ -22,7 +23,7 @@ jobs:
       - name: Check remote head hash
         id: zenoh-c-head
         shell: bash
-        run: '{ echo -n "Zenoh_C_HEAD="; git ls-remote "$Zenoh_C_Repo" HEAD | cut -f1; } | tee -a "$GITHUB_OUTPUT"'
+        run: '{ echo -n "Zenoh_C_HEAD="; git ls-remote "$Zenoh_C_Repo" "$Zenoh_C_Build_Rev" | cut -f1; } | tee -a "$GITHUB_OUTPUT"'
 
       - name: Cache compiled zenoh-c library
         id: cache-libzenohc
@@ -63,6 +64,7 @@ jobs:
     env:
       UP_CPP_Repo: https://github.com/eclipse-uprotocol/up-cpp.git
       UP_CPP_Cache_PFX: up-cpp-conan2
+      UP_CPP_Build_Rev: HEAD
     outputs:
       UP_CPP_Cache: ${{ env.UP_CPP_Cache_PFX }}-${{ steps.up-cpp-head.outputs.UP_CPP_HEAD }}
 
@@ -70,7 +72,7 @@ jobs:
       - name: Check remote head hash
         id: up-cpp-head
         shell: bash
-        run: '{ echo -n "UP_CPP_HEAD="; git ls-remote "$UP_CPP_Repo" HEAD | cut -f1; } | tee -a "$GITHUB_OUTPUT"'
+        run: '{ echo -n "UP_CPP_HEAD="; git ls-remote "$UP_CPP_Repo" "$UP_CPP_Build_Rev" | cut -f1; } | tee -a "$GITHUB_OUTPUT"'
 
       - name: Cache conan artifacts
         id: cache-conan2
@@ -120,6 +122,7 @@ jobs:
     env:
       UP_Client_Z_Repo: eclipse-uprotocol/up-client-zenoh-cpp
       UP_Client_Z_Cache_PFX: up-client-zenoh-conan2
+      UP_Client_Z_Build_Rev: HEAD
       Zenoh_C_Cache: ${{ needs.build-zenoh-c.outputs.Zenoh_C_Cache }}
       UP_CPP_Cache: ${{ needs.build-up-cpp.outputs.UP_CPP_Cache }}
     outputs:
@@ -129,13 +132,13 @@ jobs:
       - name: Check remote head hash
         id: up-client-zenoh-head
         shell: bash
-        run: '{ echo -n "UP_Client_Z_HEAD="; git ls-remote "https://github.com/$UP_Client_Z_Repo".git HEAD | cut -f1; } | tee -a "$GITHUB_OUTPUT"'
+        run: '{ echo -n "UP_Client_Z_HEAD="; git ls-remote "https://github.com/$UP_Client_Z_Repo".git "$UP_Client_Z_Build_Rev" | cut -f1; } | tee -a "$GITHUB_OUTPUT"'
 
       - name: Cache client artifacts
         id: cache-z-client
         uses: actions/cache@v4
         with:
-          key: ${{ env.UP_Client_Z_Cache_PFX }}-${{ steps.up-client-zenoh-head.outputs.UP_Client_Z_HEAD }}
+          key: ${{ env.UP_Client_Z_Cache_PFX }}-${{ steps.up-client-zenoh-head.outputs.UP_Client_Z_HEAD }}-${{ env.Zenoh_C_Cache }}-${{ env.UP_CPP_Cache }}
           path: |
             ~/.conan2
             ~/local
@@ -219,10 +222,10 @@ jobs:
           mkdir build
           cd build
           conan install ..
-          cmake -S .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release 
+          cmake -S .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release
           cmake --build .
 
-  
+
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged
   # from branches where specific status checks have passed. These checks are

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,4 +24,4 @@ cmake_minimum_required(VERSION 3.20)
 project(samples VERSION 0.1.0 LANGUAGES CXX)
 
 add_subdirectory(pubsub)
-add_subdirectory(rpc)
+#add_subdirectory(rpc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,4 +24,4 @@ cmake_minimum_required(VERSION 3.20)
 project(samples VERSION 0.1.0 LANGUAGES CXX)
 
 add_subdirectory(pubsub)
-#add_subdirectory(rpc)
+add_subdirectory(rpc)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 
-class HelloWorldRecipe(ConanFile):
+class UpZenohExampleRecipe(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "CMakeDeps", "CMakeToolchain", "PkgConfigDeps", "VirtualRunEnv", "VirtualBuildEnv"
     options = {
@@ -19,14 +19,12 @@ class HelloWorldRecipe(ConanFile):
         "build_cross_compiling": False,
     }
 
-    # def configure(self):
-    #     self.options["spdlog"].shared = self.options.shared
-
     def requirements(self):
-        self.requires("up-client-zenoh-cpp/0.1.0-dev")
+        self.requires("spdlog/1.13.0")
+        self.requires("up-cpp/0.1.1-dev")
+        self.requires("up-client-zenoh-cpp/0.1.2-dev")
         self.requires("protobuf/3.21.12" + ("@cross/cross" if self.options.build_cross_compiling else ""))
             
-
     def imports(self):
         if self.options.build_testing:
             self.copy("*.so*", dst="lib", keep_path=False)

--- a/pubsub/CMakeLists.txt
+++ b/pubsub/CMakeLists.txt
@@ -35,12 +35,28 @@ else()
     find_library(ZENOH_LIB zenohc)
 endif() 
 
+if(BUILD_UNBUNDLED)
+    find_package(zenohc REQUIRED)
+    set(ZENOH_LIBRARY zenohc::lib)
+else()
+    if(CROSS_COMPILE)
+        find_package(zenohc REQUIRED)
+	set(ZENOH_LIBRARY zenohc::lib)
+    else()
+        find_library(ZENOH_LIB zenohc)
+	set(ZENOH_LIBRARY ${ZENOH_LIB})
+    endif()
+endif()
+
+message("MICHAEL ${ZENOH_LIBRARY}")
+
 # sub
 add_executable(sub src/main_sub.cpp)
 target_link_libraries(sub
     PUBLIC
-        ${ZENOH_LIB}
-        up-client-zenoh-cpp::up-client-zenoh-cpp)
+        up-client-zenoh-cpp::up-client-zenoh-cpp
+    PRIVATE
+        ${ZENOH_LIBRARY})
 
 target_include_directories(sub 
     PUBLIC
@@ -53,8 +69,9 @@ target_include_directories(sub
 add_executable(pub src/main_pub.cpp)
 target_link_libraries(pub
     PUBLIC
-        ${ZENOH_LIB}
-        up-client-zenoh-cpp::up-client-zenoh-cpp)
+        up-client-zenoh-cpp::up-client-zenoh-cpp
+    PRIVATE
+        ${ZENOH_LIBRARY})
 
 target_include_directories(pub 
     PUBLIC

--- a/pubsub/CMakeLists.txt
+++ b/pubsub/CMakeLists.txt
@@ -30,25 +30,23 @@ find_package(up-cpp QUIET)
 add_definitions(-DSPDLOG_FMT_EXTERNAL)
 
 if(DEFINED ENV{GITHUB_CICD_ZENOH_PATH})
-    set(ZENOH_LIB $ENV{GITHUB_CICD_ZENOH_PATH})
+    set(ZENOH_LINK_FLAGS -Wl,--no-as-needed)
+    set(LIB_SEARCH -L$ENV{GITHUB_CICD_ZENOH_PATH})
+    set(ZENOH_LIBRARY -lzenohc)
 else()
-    find_library(ZENOH_LIB zenohc)
-endif() 
 
-if(BUILD_UNBUNDLED)
-    find_package(zenohc REQUIRED)
-    set(ZENOH_LIBRARY zenohc::lib)
-else()
-    if(CROSS_COMPILE)
+    if(BUILD_UNBUNDLED)
         find_package(zenohc REQUIRED)
-	set(ZENOH_LIBRARY zenohc::lib)
+        set(ZENOH_LIBRARY zenohc::lib)
     else()
-        find_library(ZENOH_LIB zenohc)
-	set(ZENOH_LIBRARY ${ZENOH_LIB})
+        if(CROSS_COMPILE)
+            find_package(zenohc REQUIRED)
+            set(ZENOH_LIBRARY zenohc::lib)
+        else()
+            find_library(ZENOH_LIBRARY zenohc)
+        endif()
     endif()
 endif()
-
-message("MICHAEL ${ZENOH_LIBRARY}")
 
 # sub
 add_executable(sub src/main_sub.cpp)
@@ -56,9 +54,11 @@ target_link_libraries(sub
     PUBLIC
         up-client-zenoh-cpp::up-client-zenoh-cpp
     PRIVATE
+        ${LIB_SEARCH}
+        ${ZENOH_LINK_FLAGS}
         ${ZENOH_LIBRARY})
 
-target_include_directories(sub 
+target_include_directories(sub
     PUBLIC
         $ENV{CMAKE_ZENOH_INCLUDE_PATH}
         ${fmt_INCLUDE_DIR}
@@ -71,9 +71,11 @@ target_link_libraries(pub
     PUBLIC
         up-client-zenoh-cpp::up-client-zenoh-cpp
     PRIVATE
+        ${LIB_SEARCH}
+        ${ZENOH_LINK_FLAGS}
         ${ZENOH_LIBRARY})
 
-target_include_directories(pub 
+target_include_directories(pub
     PUBLIC
         $ENV{CMAKE_ZENOH_INCLUDE_PATH}
         ${fmt_INCLUDE_DIR}

--- a/pubsub/CMakeLists.txt
+++ b/pubsub/CMakeLists.txt
@@ -23,16 +23,42 @@
 cmake_minimum_required(VERSION 3.20)
 project(pubsub VERSION 0.1.0 LANGUAGES CXX)
 
-find_package(up-client-zenoh-cpp REQUIRED)
+find_package(spdlog REQUIRED)
+find_package(up-client-zenoh-cpp QUIET)
+find_package(up-cpp QUIET)
+
+add_definitions(-DSPDLOG_FMT_EXTERNAL)
+
+if(DEFINED ENV{GITHUB_CICD_ZENOH_PATH})
+    set(ZENOH_LIB $ENV{GITHUB_CICD_ZENOH_PATH})
+else()
+    find_library(ZENOH_LIB zenohc)
+endif() 
 
 # sub
 add_executable(sub src/main_sub.cpp)
 target_link_libraries(sub
-    PRIVATE
+    PUBLIC
+        ${ZENOH_LIB}
         up-client-zenoh-cpp::up-client-zenoh-cpp)
+
+target_include_directories(sub 
+    PUBLIC
+        $ENV{CMAKE_ZENOH_INCLUDE_PATH}
+        ${fmt_INCLUDE_DIR}
+        ${spdlog_INCLUDE_DIR}
+        ${up-cpp_INCLUDE_DIR})
 
 # pub
 add_executable(pub src/main_pub.cpp)
 target_link_libraries(pub
-    PRIVATE
+    PUBLIC
+        ${ZENOH_LIB}
         up-client-zenoh-cpp::up-client-zenoh-cpp)
+
+target_include_directories(pub 
+    PUBLIC
+        $ENV{CMAKE_ZENOH_INCLUDE_PATH}
+        ${fmt_INCLUDE_DIR}
+        ${spdlog_INCLUDE_DIR}
+        ${up-cpp_INCLUDE_DIR})

--- a/rpc/CMakeLists.txt
+++ b/rpc/CMakeLists.txt
@@ -27,21 +27,36 @@ find_package(spdlog REQUIRED)
 find_package(up-client-zenoh-cpp QUIET)
 find_package(up-cpp QUIET)
 
-# this is needed until zenoh will be released to the public conan central
-if(DEFINED ENV{GITHUB_CICD_ZENOH_PATH})
-    set(ZENOH_LIB $ENV{GITHUB_CICD_ZENOH_PATH})
-else()
-    find_library(ZENOH_LIB zenohc)
-endif() 
-
 add_definitions(-DSPDLOG_FMT_EXTERNAL)
+
+if(DEFINED ENV{GITHUB_CICD_ZENOH_PATH})
+    set(ZENOH_LINK_FLAGS -Wl,--no-as-needed)
+    set(LIB_SEARCH -L$ENV{GITHUB_CICD_ZENOH_PATH})
+    set(ZENOH_LIBRARY -lzenohc)
+else()
+
+    if(BUILD_UNBUNDLED)
+        find_package(zenohc REQUIRED)
+        set(ZENOH_LIBRARY zenohc::lib)
+    else()
+        if(CROSS_COMPILE)
+            find_package(zenohc REQUIRED)
+            set(ZENOH_LIBRARY zenohc::lib)
+        else()
+            find_library(ZENOH_LIBRARY zenohc)
+        endif()
+    endif()
+endif()
 
 # rpc client
 add_executable(rpc_client src/main_rpc_client.cpp)
 target_link_libraries(rpc_client
     PUBLIC
-        ${ZENOH_LIB}
-        up-client-zenoh-cpp::up-client-zenoh-cpp)
+        up-client-zenoh-cpp::up-client-zenoh-cpp
+    PRIVATE
+        ${LIB_SEARCH}
+        ${ZENOH_LINK_FLAGS}
+        ${ZENOH_LIBRARY})
 
 target_include_directories(rpc_client 
     PUBLIC
@@ -54,8 +69,11 @@ target_include_directories(rpc_client
 add_executable(rpc_server src/main_rpc_server.cpp)
 target_link_libraries(rpc_server
     PUBLIC
-        ${ZENOH_LIB}
-        up-client-zenoh-cpp::up-client-zenoh-cpp)
+        up-client-zenoh-cpp::up-client-zenoh-cpp
+    PRIVATE
+        ${LIB_SEARCH}
+        ${ZENOH_LINK_FLAGS}
+        ${ZENOH_LIBRARY})
 
 target_include_directories(rpc_server 
     PUBLIC

--- a/rpc/CMakeLists.txt
+++ b/rpc/CMakeLists.txt
@@ -23,16 +23,43 @@
 cmake_minimum_required(VERSION 3.20)
 project(rpc VERSION 0.1.0 LANGUAGES CXX)
 
-find_package(up-client-zenoh-cpp REQUIRED)
+find_package(spdlog REQUIRED)
+find_package(up-client-zenoh-cpp QUIET)
+find_package(up-cpp QUIET)
 
-# rpc server
-add_executable(rpc_server src/main_rpc_server.cpp)
-target_link_libraries(rpc_server
-    PRIVATE
-        up-client-zenoh-cpp::up-client-zenoh-cpp)
+# this is needed until zenoh will be released to the public conan central
+if(DEFINED ENV{GITHUB_CICD_ZENOH_PATH})
+    set(ZENOH_LIB $ENV{GITHUB_CICD_ZENOH_PATH})
+else()
+    find_library(ZENOH_LIB zenohc)
+endif() 
+
+add_definitions(-DSPDLOG_FMT_EXTERNAL)
 
 # rpc client
 add_executable(rpc_client src/main_rpc_client.cpp)
 target_link_libraries(rpc_client
-    PRIVATE
+    PUBLIC
+        ${ZENOH_LIB}
         up-client-zenoh-cpp::up-client-zenoh-cpp)
+
+target_include_directories(rpc_client 
+    PUBLIC
+        $ENV{CMAKE_ZENOH_INCLUDE_PATH}
+        ${fmt_INCLUDE_DIR}
+        ${spdlog_INCLUDE_DIR}
+        ${up-cpp_INCLUDE_DIR})
+
+# rpc server
+add_executable(rpc_server src/main_rpc_server.cpp)
+target_link_libraries(rpc_server
+    PUBLIC
+        ${ZENOH_LIB}
+        up-client-zenoh-cpp::up-client-zenoh-cpp)
+
+target_include_directories(rpc_server 
+    PUBLIC
+        $ENV{CMAKE_ZENOH_INCLUDE_PATH}
+        ${fmt_INCLUDE_DIR}
+        ${spdlog_INCLUDE_DIR}
+        ${up-cpp_INCLUDE_DIR})


### PR DESCRIPTION
Iterating on fixes for CI jobs can be time consuming, particularly when the issue exists at the end of a pipeline where some components take *several minutes* to build.

![must go faster](https://github.com/eclipse-uprotocol/up-client-zenoh-cpp/assets/10570177/504598b0-cd30-4cd7-9b4c-20b331cd5541)

I used these CI changes during the investigations leading to the CI fix in #9. By caching results for build dependencies, test cycles were reduced by around four minutes. The main time savings come from:

1. Running stages with no interdependencies in parallel (up-cpp and zenoh-c)
2. Caching artifacts for all stages leading up to the build for up-zenoh-example-cpp

The caches are tied to each repo's HEAD position, so if new commits are added the caches for that build stage are invalidated. Subsequent build stages will also re-run. Configuration parameters are provided for selecting a different named revision, if needed.

This uses the same pattern as https://github.com/eclipse-uprotocol/up-client-zenoh-cpp/pull/33, with only a small adjustment to caching structure and an additional stage for the examples from this repo.

----

## This PR must wait until #9 is merged before it can be committed.<br>Use ➡️ **[this link](https://github.com/eclipse-uprotocol/up-zenoh-example-cpp/pull/10/files/635b54a2a9ae96409f8b121a564e76758f8acde9..ea42fc2e8a328635109a968c7819ad46ca02dee6)** ⬅️ to review the changes that are added by this PR.