### PR TITLE
Cleaning up extra printed messages added during debugging

### DIFF
--- a/rpc/src/main_rpc_client.cpp
+++ b/rpc/src/main_rpc_client.cpp
@@ -82,6 +82,7 @@ int main(int argc,
     std::shared_ptr<UpZenohClient> rpcClient = UpZenohClient::instance(
             BuildUAuthority().setName("device1").build(),
             BuildUEntity().setName("rpc.client").setMajorVersion(1).setId(1).build());
+
     /* init RPC client */
     if (nullptr == rpcClient) {
         spdlog::error("init failed");
@@ -93,14 +94,14 @@ int main(int argc,
     while (!gTerminate) {
 
         auto response = sendRPC(rpcUri);
-        cout << "response.status.code()=" << response.status.code() << endl;
-        cout << "response.message.payload=" << string_view((const char*)response.message.payload().data(), response.message.payload().size()) << endl;
+        const auto& payload = response.message.payload();
 
-        uint64_t milliseconds = 0;
-
-        if (response.message.payload().data() != nullptr && response.message.payload().size() >= sizeof(uint64_t)) {
-            memcpy(&milliseconds, response.message.payload().data(), sizeof(uint64_t));
+        if (payload.data() != nullptr && payload.size() >= sizeof(uint64_t)) {
+            uint64_t milliseconds = 0;
+            memcpy(&milliseconds, payload.data(), sizeof(uint64_t));
             spdlog::info("Received = {}", milliseconds);
+        } else {
+            spdlog::error("Invalid message of size {}", payload.size());
         }
 
         sleep(1);

--- a/rpc/src/main_rpc_server.cpp
+++ b/rpc/src/main_rpc_server.cpp
@@ -51,27 +51,30 @@ class RpcListener : public UListener {
     public:
        
          UStatus onReceive(UMessage &message) const override {
-            using namespace std;
-            cout << "top of onReceive" << endl;
             /* Construct response payload with the current time */
-            // auto currentTime = std::chrono::system_clock::now();
-            // auto duration = currentTime.time_since_epoch();
-            // uint64_t currentTimeMilli = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
-            // UPayload responsePayload(reinterpret_cast<const uint8_t*>(&currentTimeMilli), sizeof(currentTimeMilli), UPayloadType::VALUE);
-            std::string data = "server_data";
-            UPayload responsePayload((const uint8_t*)data.data(), data.size(), UPayloadType::VALUE);
-           
-            auto builder = UAttributesBuilder::response(message.attributes().source(), message.attributes().sink(), UPriority::UPRIORITY_CS0, message.attributes().id());
+            auto currentTime = std::chrono::system_clock::now();
+            uint64_t currentTimeMilli =
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                        currentTime.time_since_epoch()).count();
+
+            UPayload responsePayload(
+                    reinterpret_cast<const uint8_t*>(&currentTimeMilli),
+                    sizeof(currentTimeMilli),
+                    UPayloadType::VALUE);
+
             /* Build response attributes - the same UUID should be used to send the response 
              * it is also possible to send the response outside of the callback context */
+            auto builder = UAttributesBuilder::response(
+                    message.attributes().sink(),
+                    message.attributes().source(),
+                    message.attributes().priority(),
+                    message.attributes().id());
 
             UAttributes responseAttributes = builder.build();
-
             UMessage messageResp(responsePayload, responseAttributes);
+
             /* Send the response */
-            cout << "sending response" << endl;
             auto ret =  UpZenohClient::instance()->send(messageResp);
-            cout << "after sending response" << endl;
             return ret;
         }
 };


### PR DESCRIPTION
While debugging the RPC timeout issue, several extra messages were added and the reply data format were changed. Changing these back so the example is cleaner and outputs the expected time value.