### PR TITLE
updated signature to be compatible with latest up-cpp version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: up-zenoh-example-cpp
-          repository: eclipse-uprotocol/up-zenoh-example-cpp
 
       - name: Fetch up-cpp conan recipe
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build up-core-api conan recipe
         shell: bash
         run: |
-          conan create --version 1.6.0 up-conan-recipes/up-core-api/release
+          conan create --version 1.6.0-alpha4 up-conan-recipes/up-core-api/release
 
       - name: Build up-cpp conan recipe
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build up-core-api conan recipe
         shell: bash
         run: |
-          conan create --version 1.6.0-alpha4 up-conan-recipes/up-core-api/release
+          conan create --version 1.6.0-alpha4 --build=missing up-conan-recipes/up-core-api/release
 
       - name: Build up-cpp conan recipe
         shell: bash

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,7 +1,7 @@
 [requires]
 up-cpp/[^1.0.1, include_prerelease]
 spdlog/[~1.13]
-up-core-api/1.6.0
+up-core-api/1.6.0-alpha4
 protobuf/[>=3.21.12]
 up-transport-socket-cpp/[>=1.0.0, include_prerelease]
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,7 +1,7 @@
 [requires]
 up-cpp/[^1.0.1, include_prerelease]
 spdlog/[~1.13]
-up-core-api/1.6.0-alpha4
+up-core-api/[^1.6, include_prerelease]
 protobuf/[>=3.21.12]
 up-transport-socket-cpp/[>=1.0.0, include_prerelease]
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,7 +1,7 @@
 [requires]
 up-cpp/[^1.0.1, include_prerelease]
 spdlog/[~1.13]
-up-core-api/[^1.6, include_prerelease]
+up-core-api/1.6.0-alpha4
 protobuf/[>=3.21.12]
 up-transport-socket-cpp/[>=1.0.0, include_prerelease]
 

--- a/pubsub/src/UTransportDomainSockets.h
+++ b/pubsub/src/UTransportDomainSockets.h
@@ -42,7 +42,7 @@ private:
 
 	void notifyListener(const v1::UMessage& message);
 	void listenThread();  // listen for incoming messages (thread)
-	void cleanupListener(CallableConn listener) override {}
+	void cleanupListener(const CallableConn& listener) override {}
 };  // class UTransportDomainSockets
 
 #endif  // UTRANSPORT_DOMAIN_SOCKETS_H


### PR DESCRIPTION
This PR updates the signature of cleanupListener to use a const reference to be compatible with the latest version of up-cpp.

closes #25 