### PR TITLE
updated to ZenohUTranspoart, updated signature, fixed dependencies and added clang-format.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: up-zenoh-example-cpp
-          repository: eclipse-uprotocol/up-zenoh-example-cpp
 
       - name: Fetch up-cpp conan recipe
         uses: actions/checkout@v4
@@ -39,17 +38,27 @@ jobs:
       - name: Build up-core-api conan recipe
         shell: bash
         run: |
-          conan create --version 1.6.0 up-conan-recipes/up-core-api/release
+          conan create --version 1.6.0-alpha4 --build=missing up-conan-recipes/up-core-api/release
 
       - name: Build up-cpp conan recipe
         shell: bash
         run: |
-          conan create --version 1.0.1-rc1 --build=missing up-conan-recipes/up-cpp/release
+          conan create --version 1.0.1-dev --build=missing up-conan-recipes/up-cpp/developer
 
-      - name: Build up-transport-socket-cpp recipe
+      - name: Build zenoh-c recipe
         shell: bash
         run: |
-          conan create --version 1.0.0-dev --build=missing up-conan-recipes/up-transport-socket-cpp/developer
+          conan create --version 1.2.1 up-conan-recipes/zenohc-tmp/prebuilt
+
+      - name: Build zenoh-cpp recipe
+        shell: bash
+        run: |
+          conan create --version 1.2.1 up-conan-recipes/zenohcpp-tmp/from-source
+
+      - name: Build up-transport-zenoh-cpp recipe
+        shell: bash
+        run: |
+          conan create --version 1.0.0-dev --build=missing up-conan-recipes/up-transport-zenoh-cpp/developer
 
       - name: Build the project
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,11 @@ cmake_minimum_required(VERSION 3.20)
 project(samples VERSION 0.1.0 LANGUAGES CXX DESCRIPTION "C++ Examples for uProtocol")
 
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
-	set(CMAKE_CXX_STANDARD 17)
-	# place libraries in a lib directory and executables in a bin directory,
-	set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-	set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+  set(CMAKE_CXX_STANDARD 17)
+  # place libraries in a lib directory and executables in a bin directory,
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 endif()
 
 add_subdirectory(pubsub)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,9 +1,10 @@
 [requires]
-up-cpp/[^1.0.1, include_prerelease]
+up-cpp/1.0.1-dev
 spdlog/[~1.13]
-up-core-api/1.6.0
+up-core-api/1.6.0-alpha4
 protobuf/[>=3.21.12]
-up-transport-socket-cpp/[>=1.0.0, include_prerelease]
+up-transport-zenoh-cpp/1.0.0-dev
+zenohcpp/1.2.1
 
 [test_requires]
 gtest/[~1.14]

--- a/lint/clang-format.sh
+++ b/lint/clang-format.sh
@@ -1,3 +1,13 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
 #!/bin/bash
 
 PROJECT_ROOT="$(realpath "$(dirname "$0")/../")"

--- a/lint/clang-format.sh
+++ b/lint/clang-format.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+PROJECT_ROOT="$(realpath "$(dirname "$0")/../")"
+
+if [ -n "$(which clang-format-13)" ]; then
+    # NOTE: Using clang-format-13 in CI system, too
+    FORMATTER=clang-format-13
+elif [ -n "$(which clang-format)" ]; then
+    echo "Did not find clang-format-13. Trying clang-format. Results may not"
+    echo "match formatting in GitHub CI process."
+    FORMATTER=clang-format
+else
+    echo "Could not find clang-format. Please make sure it is installed" 1>&2
+    exit 2
+fi
+
+echo "Running $FORMATTER on all files in '$PROJECT_ROOT'"
+shopt -s globstar
+
+pushd "$PROJECT_ROOT" > /dev/null
+for f in **/*.h **/*.cpp; do
+	if [[ ! ("$f" =~ "build/") ]]; then
+		echo
+		echo "Checking file '$f'"
+		$FORMATTER -i "$f"
+	fi
+done
+popd > /dev/null

--- a/pubsub/CMakeLists.txt
+++ b/pubsub/CMakeLists.txt
@@ -25,16 +25,17 @@ project(pubsub VERSION 0.1.0 LANGUAGES CXX)
 
 find_package(spdlog REQUIRED)
 find_package(up-cpp REQUIRED)
+find_package(up-transport-zenoh-cpp REQUIRED)
 
 add_definitions(-DSPDLOG_FMT_EXTERNAL)
 
 # sub
 add_executable(sub src/main_sub.cpp src/UTransportDomainSockets.cpp)
 target_link_libraries(sub
-    PUBLIC
-        spdlog::spdlog
-        up-cpp::up-cpp
-        up-core-api::up-core-api)
+  PUBLIC
+    spdlog::spdlog
+    up-cpp::up-cpp
+    up-core-api::up-core-api)
 target_include_directories(sub
 	PRIVATE
 	include)
@@ -42,10 +43,10 @@ target_include_directories(sub
 # pub
 add_executable(pub src/main_pub.cpp src/UTransportDomainSockets.cpp)
 target_link_libraries(pub
-    PUBLIC
-        spdlog::spdlog
-        up-cpp::up-cpp
-        up-core-api::up-core-api)
+  PUBLIC
+    spdlog::spdlog
+    up-cpp::up-cpp
+    up-core-api::up-core-api)
 target_include_directories(pub
-	PRIVATE
-	include)
+  PRIVATE
+    include)

--- a/pubsub/include/common.h
+++ b/pubsub/include/common.h
@@ -35,18 +35,18 @@ uprotocol::v1::UUri getUUri(int const resource_id) {
 }
 
 uprotocol::v1::UUri const& getTimeUUri() {
-    static auto uuri = getUUri(0x8001);
-    return uuri;
+	static auto uuri = getUUri(0x8001);
+	return uuri;
 }
 
 uprotocol::v1::UUri const& getRandomUUri() {
-    static auto uuri = getUUri(0x8002);
-    return uuri;
+	static auto uuri = getUUri(0x8002);
+	return uuri;
 }
 
 uprotocol::v1::UUri const& getCounterUUri() {
-    static auto uuri = getUUri(0x8003);
-    return uuri;
+	static auto uuri = getUUri(0x8003);
+	return uuri;
 }
 
-#endif // PUBSUB_COMMON_H
+#endif  // PUBSUB_COMMON_H

--- a/pubsub/src/UTransportDomainSockets.h
+++ b/pubsub/src/UTransportDomainSockets.h
@@ -42,7 +42,7 @@ private:
 
 	void notifyListener(const v1::UMessage& message);
 	void listenThread();  // listen for incoming messages (thread)
-	void cleanupListener(CallableConn listener) override {}
+	void cleanupListener(const CallableConn& listener) override {}
 };  // class UTransportDomainSockets
 
 #endif  // UTRANSPORT_DOMAIN_SOCKETS_H

--- a/rpc/CMakeLists.txt
+++ b/rpc/CMakeLists.txt
@@ -25,30 +25,30 @@ project(rpc VERSION 0.1.0 LANGUAGES CXX)
 
 find_package(spdlog REQUIRED)
 find_package(up-cpp REQUIRED)
-find_package(up-transport-socket-cpp REQUIRED)
+find_package(up-transport-zenoh-cpp REQUIRED)
 
 add_definitions(-DSPDLOG_FMT_EXTERNAL)
 
 # rpc client
 add_executable(rpc_client src/main_rpc_client.cpp)
 target_link_libraries(rpc_client
-    PUBLIC
-	spdlog::spdlog
-        up-cpp::up-cpp
-        up-core-api::up-core-api
-	up-transport-socket-cpp::up-transport-socket-cpp)
+  PUBLIC
+    spdlog::spdlog
+    up-cpp::up-cpp
+    up-core-api::up-core-api
+    up-transport-zenoh-cpp::up-transport-zenoh-cpp)
 target_include_directories(rpc_client 
-    PRIVATE
-        include)
+  PRIVATE
+    include)
 
 # rpc server
 add_executable(rpc_server src/main_rpc_server.cpp)
 target_link_libraries(rpc_server
-    PUBLIC
-	spdlog::spdlog
-        up-cpp::up-cpp
-        up-core-api::up-core-api
-	up-transport-socket-cpp::up-transport-socket-cpp)
+  PUBLIC
+    spdlog::spdlog
+    up-cpp::up-cpp
+    up-core-api::up-core-api
+	up-transport-zenoh-cpp::up-transport-zenoh-cpp)
 target_include_directories(rpc_server 
-    PRIVATE
-        include)
+  PRIVATE
+    include)

--- a/rpc/include/common.h
+++ b/rpc/include/common.h
@@ -26,12 +26,12 @@
 #include <uprotocol/v1/uri.pb.h>
 
 uprotocol::v1::UUri getRpcUUri(const int resource_id) {
-    uprotocol::v1::UUri uuri;
-    uuri.set_authority_name("test_rpc.app");
-    uuri.set_ue_id(0x10001);
-    uuri.set_ue_version_major(1);
-    uuri.set_resource_id(resource_id);
-    return uuri;
+	uprotocol::v1::UUri uuri;
+	uuri.set_authority_name("test_rpc.app");
+	uuri.set_ue_id(0x10001);
+	uuri.set_ue_version_major(1);
+	uuri.set_resource_id(resource_id);
+	return uuri;
 }
 
-#endif // RPC_COMMON_H
+#endif  // RPC_COMMON_H

--- a/rpc/resources/DEFAULT_CONFIG.json5
+++ b/rpc/resources/DEFAULT_CONFIG.json5
@@ -1,3 +1,14 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
 /// This file attempts to list and document available configuration elements.
 /// For a more complete view of the configuration's structure, check out `zenoh/src/config.rs`'s `Config` structure.
 /// Note that the values here are correctly typed, but may not be sensible, so copying this file to change only the parts that matter to you is not good practice.

--- a/rpc/resources/DEFAULT_CONFIG.json5
+++ b/rpc/resources/DEFAULT_CONFIG.json5
@@ -1,0 +1,21 @@
+/// This file attempts to list and document available configuration elements.
+/// For a more complete view of the configuration's structure, check out `zenoh/src/config.rs`'s `Config` structure.
+/// Note that the values here are correctly typed, but may not be sensible, so copying this file to change only the parts that matter to you is not good practice.
+{
+  /// The identifier (as unsigned 128bit integer in hexadecimal lowercase - leading zeros are not accepted)
+  /// that zenoh runtime will use.
+  /// If not set, a random unsigned 128bit integer will be used.
+  /// WARNING: this id must be unique in your zenoh network.
+  // id: "1234567890abcdef",
+
+  /// The node's mode (router, peer or client)
+  mode: "peer",
+
+  connect: {
+    timeout_ms: { router: -1, peer: -1, client: -1 },
+    endpoints: [
+      // "<proto>/<address>"
+    ],
+  },
+  queries_default_timeout: 10000
+}

--- a/rpc/src/main_rpc_client.cpp
+++ b/rpc/src/main_rpc_client.cpp
@@ -24,17 +24,18 @@
 #include <spdlog/spdlog.h>
 #include <unistd.h>
 #include <up-cpp/communication/RpcClient.h>
+#include <up-transport-zenoh-cpp/ZenohUTransport.h>
 
 #include <chrono>
 #include <csignal>
 #include <iostream>
 
-#include "SocketUTransport.h"
 #include "common.h"
 
 using namespace uprotocol::v1;
 using namespace uprotocol::communication;
 using namespace uprotocol::datamodel::builder;
+using ZenohUTransport = uprotocol::transport::ZenohUTransport;
 
 bool gTerminate = false;
 
@@ -83,11 +84,17 @@ int main(int argc, char** argv) {
 	(void)argc;
 	(void)argv;
 
+	if (argc < 2) {
+		std::cout << "No Zenoh config has been provided" << std::endl;
+		std::cout << "Usage: rpc_client <config_file>" << std::endl;
+		return 1;
+	}
+
 	signal(SIGINT, signalHandler);
 
 	UUri source = getRpcUUri(0);
 	UUri method = getRpcUUri(12);
-	auto transport = std::make_shared<SocketUTransport>(source);
+	auto transport = std::make_shared<ZenohUTransport>(source, argv[1]);
 	auto client =
 	    RpcClient(transport, std::move(method), UPriority::UPRIORITY_CS4,
 	              std::chrono::milliseconds(500));
@@ -100,4 +107,3 @@ int main(int argc, char** argv) {
 
 	return 0;
 }
-

--- a/rpc/src/main_rpc_server.cpp
+++ b/rpc/src/main_rpc_server.cpp
@@ -24,17 +24,19 @@
 #include <spdlog/spdlog.h>
 #include <unistd.h>
 #include <up-cpp/communication/RpcServer.h>
+#include <up-transport-zenoh-cpp/ZenohUTransport.h>
 
 #include <chrono>
 #include <csignal>
+#include <filesystem>
 #include <iostream>
 
-#include "SocketUTransport.h"
 #include "common.h"
 
 using namespace uprotocol::v1;
 using namespace uprotocol::communication;
 using namespace uprotocol::datamodel::builder;
+using ZenohUTransport = uprotocol::transport::ZenohUTransport;
 
 bool gTerminate = false;
 
@@ -87,11 +89,16 @@ int main(int argc, char** argv) {
 	(void)argc;
 	(void)argv;
 
-	signal(SIGINT, signalHandler);
+	if (argc < 2) {
+		std::cout << "No Zenoh config has been provided" << std::endl;
+		std::cout << "Usage: rpc_server <config_file>" << std::endl;
+		return 1;
+	}
 
+	signal(SIGINT, signalHandler);
 	UUri source = getRpcUUri(0);
 	UUri method = getRpcUUri(12);
-	auto transport = std::make_shared<SocketUTransport>(source);
+	auto transport = std::make_shared<ZenohUTransport>(source, argv[1]);
 	auto server = RpcServer::create(transport, method, OnReceive);
 
 	if (!server.has_value()) {
@@ -106,4 +113,3 @@ int main(int argc, char** argv) {
 
 	return 0;
 }
-


### PR DESCRIPTION
This PR targets the following issues:
- Replaces SocketUTransport with ZenohUTransport
- update the signature of cleanupListener to make it compatible with the recent changes of up-cpp
- update the dependencies after the changes in up-cpp
- added clang-format.sh like in up-cpp

Closes #23 #24 #25 #27