### PR TITLE
Small changes for alpha4

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ $ cmake --build . -- -j
 ```
 
 ## Usage
-After completing the project build, the build artifacts can generally be found in the `build/Release/bin` directory within your workspace.
-You can run the example using the supplied configuration file located in the `/resources` directory.For instance, to run the RPC example, use the following commands:
+After building the project, the build artifacts can generally be found in the `build/Release/bin` directory within your workspace.
+You can run the example using the supplied configuration file located in the `/resources` directory. For instance, to run the RPC example, use the following commands:
 
-```bash
+```
 $ ./rpc_server <path/to/config>
 $ ./rpc_client <path/to/config>
 ```

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-up-cpp/1.0.1-dev
+up-cpp/[^1.0.1, include_prerelease]
 spdlog/[~1.13]
 up-core-api/1.6.0-alpha4
 protobuf/[>=3.21.12]

--- a/lint/clang-tidy.sh
+++ b/lint/clang-tidy.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+PROJECT_ROOT="$(realpath "$(dirname "$0")/../")"
+
+if [ -n "$(which clang-tidy-13)" ]; then
+    # NOTE: Using clang-tidy-13 in CI system, too
+    LINTER=clang-tidy-13
+elif [ -n "$(which clang-tidy)" ]; then
+    echo "Did not find clang-tidy-13. Trying clang-tidy. Results may not"
+    echo "match formatting in GitHub CI process."
+    LINTER=clang-tidy
+else
+    echo "Could not find clang-tidy. Please make sure it is installed" 1>&2
+    exit 2
+fi
+
+usage() {
+	echo "$(basename "$0") path/to/compile_commands.json [source_to_lint]" 1>&2
+	echo 1>&2
+	echo "    compile_commands.json" 1>&2
+	echo "        Produced during a cmake build when configured with the" 1>&2
+	echo "        -DCMAKE_EXPORT_COMPILE_COMMANDS=yes flag" 1>&2
+	echo 1>&2
+	echo "    source_to_lint (optional)" 1>&2
+	echo "        Source file to run clang-tidy against. If not specified," 1>&2
+	echo "        all source files in the repo will be scanned." 1>&2
+}
+
+if [ "$1" == "-h" ] || [ "$1" == "--help" ] || [ "$1" == "/h" ] || [ "$1" == "/?" ]; then
+	usage
+	exit
+fi
+
+compile_database="$1"
+
+if [ -z "$compile_database" ]; then
+	echo "No compile database specified. Make sure cmake was configured" 1>&2
+	echo "with '-DCMAKE_EXPORT_COMPILE_COMMANDS=yes' and re-run the build" 1>&2
+	echo 1>&2
+	echo "Usage:" 1>&2
+	usage
+	exit 1
+elif [ ! -f "$compile_database" ]; then
+	echo "Compile database file not found. Make sure cmake was configured" 1>&2
+	echo "with '-DCMAKE_EXPORT_COMPILE_COMMANDS=yes' and re-run the build" 1>&2
+	echo 1>&2
+	echo "Usage:" 1>&2
+	usage
+	exit 1
+fi
+
+compile_database="$(realpath "$compile_database")"
+
+target_source="$2"
+
+if [ -z "$target_source" ]; then
+	echo "Running $LINTER on all files in '$PROJECT_ROOT'"
+	shopt -s globstar
+
+	pushd "$PROJECT_ROOT" > /dev/null
+	for f in pubsub/include/**/*.h pubsub/src/**/*.cpp rpc/include/**/*.h rpc/src/**/*.cpp; do
+		if [[ ! ("$f" =~ "build/") ]]; then
+			echo
+			echo "Checking file '$f'"
+			$LINTER -p "$(dirname "$compile_database")" "$f"
+		fi
+	done
+	popd > /dev/null
+	exit
+fi
+
+if [ ! -f "$target_source" ]; then
+	echo "Target source file '$target_source' not found." 1>&2
+	echo 1>&2
+	echo "Usage:" 1>&2
+	usage
+	exit 1
+fi
+
+echo "Running $LINTER on '$target_source'"
+$LINTER -p "$(dirname "$compile_database")" "$target_source"

--- a/pubsub/include/common.h
+++ b/pubsub/include/common.h
@@ -9,33 +9,38 @@
 //
 //  SPDX-License-Identifier: Apache-2.0
 //
-#ifndef PUBSUB_COMMON_H
-#define PUBSUB_COMMON_H
+#ifndef COMMON_H
+#define COMMON_H
 
 #include <uprotocol/v1/uri.pb.h>
 
-uprotocol::v1::UUri getUUri(int const resource_id) {
+constexpr int DUMMY_UE_ID = 0x18002;
+constexpr int TIMER_RESOURCE_ID = 0x8001;
+constexpr int RANDOM_RESOURCE_ID = 0x8002;
+constexpr int COUNTER_RESOURCE_ID = 0x8003;
+
+inline uprotocol::v1::UUri getUUri(int const resource_id) {
 	uprotocol::v1::UUri uuri;
 	uuri.set_authority_name("test.app");
-	uuri.set_ue_id(0x18002);
+	uuri.set_ue_id(DUMMY_UE_ID);
 	uuri.set_ue_version_major(1);
 	uuri.set_resource_id(resource_id);
 	return uuri;
 }
 
-uprotocol::v1::UUri const& getTimeUUri() {
-	static auto uuri = getUUri(0x8001);
+inline uprotocol::v1::UUri const& getTimeUUri() {
+	static auto uuri = getUUri(TIMER_RESOURCE_ID);
 	return uuri;
 }
 
-uprotocol::v1::UUri const& getRandomUUri() {
-	static auto uuri = getUUri(0x8002);
+inline uprotocol::v1::UUri const& getRandomUUri() {
+	static auto uuri = getUUri(RANDOM_RESOURCE_ID);
 	return uuri;
 }
 
-uprotocol::v1::UUri const& getCounterUUri() {
-	static auto uuri = getUUri(0x8003);
+inline uprotocol::v1::UUri const& getCounterUUri() {
+	static auto uuri = getUUri(COUNTER_RESOURCE_ID);
 	return uuri;
 }
 
-#endif  // PUBSUB_COMMON_H
+#endif  // COMMON_H

--- a/rpc/include/common.h
+++ b/rpc/include/common.h
@@ -9,8 +9,8 @@
 //
 //  SPDX-License-Identifier: Apache-2.0
 //
-#ifndef RPC_COMMON_H
-#define RPC_COMMON_H
+#ifndef COMMON_H
+#define COMMON_H
 
 #include <uprotocol/v1/uri.pb.h>
 constexpr uint32_t RPC_UE_ID = 0x10001;
@@ -24,4 +24,4 @@ inline uprotocol::v1::UUri getRpcUUri(const int resource_id) {
 	return uuri;
 }
 
-#endif  // RPC_COMMON_H
+#endif  // COMMON_H

--- a/rpc/src/main_rpc_client.cpp
+++ b/rpc/src/main_rpc_client.cpp
@@ -91,13 +91,12 @@ int main(int argc, char* argv[]) {
 	UUri source = getRpcUUri(0);
 	UUri method = getRpcUUri(METHOD_RPC_RESOURCE_ID);
 	auto transport = std::make_shared<ZenohUTransport>(source, args.at(1));
-	auto client = RpcClient(transport, std::move(method),
-	                        uprotocol::v1::UPriority::UPRIORITY_CS4,
+	auto client = RpcClient(transport, uprotocol::v1::UPriority::UPRIORITY_CS4,
 	                        std::chrono::milliseconds(RPCCLIENT_TTL));
 	RpcClient::InvokeHandle handle;
 
 	while (!g_terminate) {
-		handle = client.invokeMethod(OnReceive);
+		handle = client.invokeMethod(method, OnReceive);
 		sleep(1);
 	}
 


### PR DESCRIPTION
This PR provides some small changes to prepare for the release of alpha4. These include the following:
 - added a clang-tidy script to check linting
 - minor adjustments in README.md
 - changes the signature of RpcClient in the pubsub proejct to be compatible with the changes made in up-cpp. Also upped up-cpp version
 - renamed some header guards to match their file names